### PR TITLE
feat: auto assign author to assignees workflow

### DIFF
--- a/.github/workflow/auto-assign-assignees.yml
+++ b/.github/workflow/auto-assign-assignees.yml
@@ -1,0 +1,26 @@
+name: auto assign author to assignees
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-assignees:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Add assignee
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: [context.payload.pull_request.user.login]
+            })


### PR DESCRIPTION
## Issue Number

#2

## Description

> 구현 내용 및 작업한 내용

- [x] PR Open시 우측 탭의 Assignees에 작성자를 auth-assign 합니다.

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request


## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
