### PR TITLE
feat: update bottom sheet component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,9 @@
 import { useState } from 'react'
 import KakaoMap from '@/components/kakao-map/kakao-map'
 import Marker from '@/components/kakao-map/marker'
-import PlaceMapPopup from '@/components/place/place-map-popup'
+import PlaceListItem from '@/components/place/place-list-item'
+import BottomSheet from '@/components/bottom-sheet'
+import { BOTTOM_SHEET_STATE } from '@/models/interface'
 
 const Home = () => {
   const [temp, setTemp] = useState(false)
@@ -26,30 +28,30 @@ const Home = () => {
         />
       </KakaoMap>
 
-      {temp && (
-        <PlaceMapPopup
-          className="absolute bottom-5 px-5"
-          placeId="dsd3egg"
-          name="존라멘"
-          category="일식"
-          address="서울시 성동구 장터5길"
-          distance="3km"
-          image="https://images.unsplash.com/photo-1551782450-a2132b4ba21d?w=164&h=164&fit=crop&auto=format"
-          pick={{
-            hashtags: [
-              '존맛탱구리',
-              '존존맛탱구리',
-              '존맛존맛탱구리',
-              '존맛탱존맛탱구리',
-              '존맛탱구리',
-            ],
-            isLiked: false,
-            isMyPick: false,
-            numOfLikes: 122,
-            onClickLike: () => null,
-          }}
-        />
-      )}
+      <BottomSheet
+        state={temp ? BOTTOM_SHEET_STATE.Default : BOTTOM_SHEET_STATE.Collapsed}
+        body={
+          <PlaceListItem
+            placeId="fasfasfas"
+            name="존라멘"
+            address="서울시 성동구 장터5길"
+            rating={0.5}
+            pick={{
+              hashtags: [
+                '존존맛탱구리',
+                '존맛',
+                '존맛탱',
+                '존맛탱구',
+                '존맛탱구리',
+              ],
+              isLiked: false,
+              isMyPick: false,
+              numOfLikes: 122,
+              onClickLike: () => null,
+            }}
+          />
+        }
+      />
     </div>
   )
 }

--- a/src/components/bottom-sheet/bottom-sheet.stories.ts
+++ b/src/components/bottom-sheet/bottom-sheet.stories.ts
@@ -35,13 +35,13 @@ export const Default: Story = {
 export const Expanded: Story = {
   args: {
     body: 'very very long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long body content',
-    initialState: BOTTOM_SHEET_STATE.Expanded,
+    state: BOTTOM_SHEET_STATE.Expanded,
   },
 }
 
 export const Collapsed: Story = {
   args: {
     body: 'content',
-    initialState: BOTTOM_SHEET_STATE.Collapsed,
+    state: BOTTOM_SHEET_STATE.Collapsed,
   },
 }

--- a/src/components/bottom-sheet/index.tsx
+++ b/src/components/bottom-sheet/index.tsx
@@ -107,7 +107,7 @@ const BottomSheet = ({
         dragListener={false}
         dragConstraints={{ top: 0, bottom: 0 }}
         dragElastic={0}
-        onDragEnd={(event, info) => handleDragEnd(info)}
+        onDragEnd={(_, info) => handleDragEnd(info)}
         aria-expanded={bottomSheetState !== BOTTOM_SHEET_STATE.Collapsed}
       >
         {/* header */}

--- a/src/components/bottom-sheet/index.tsx
+++ b/src/components/bottom-sheet/index.tsx
@@ -40,8 +40,6 @@ const BottomSheet = ({
 
   const bodyHeight = useMemo(() => {
     switch (bottomSheetState) {
-      case BOTTOM_SHEET_STATE.Collapsed:
-        return 0
       case BOTTOM_SHEET_STATE.Expanded:
         return expandedHeight - headerHeight
       default:
@@ -113,7 +111,7 @@ const BottomSheet = ({
         aria-expanded={bottomSheetState !== BOTTOM_SHEET_STATE.Collapsed}
       >
         {/* header */}
-        <div className="pt-[16px] px-[20px] cursor-grab">
+        <div className="pt-[16px] cursor-grab">
           {/* bar */}
           <div className="w-[53px] h-[6px] bg-[#6D717A] my-0 mx-auto rounded-full" />
         </div>
@@ -124,9 +122,7 @@ const BottomSheet = ({
           aria-hidden={bottomSheetState === BOTTOM_SHEET_STATE.Collapsed}
         >
           {/* content */}
-          <div className="px-[20px] pt-[24px]" ref={contentRef}>
-            {body}
-          </div>
+          <div ref={contentRef}>{body}</div>
         </div>
       </motion.div>
     </>

--- a/src/components/bottom-sheet/index.tsx
+++ b/src/components/bottom-sheet/index.tsx
@@ -94,7 +94,7 @@ const BottomSheet = ({
     <>
       {/* container */}
       <motion.div
-        className="fixed top-0 left-0 z-10 w-screen bg-[#212124] rounded-t-[14px] pb-[24px] will-change-transform text-white"
+        className="fixed max-w-[420px] w-full z-10 bg-[#212124] rounded-t-[14px] pb-[24px] will-change-transform text-white"
         onPointerDown={(e) => dragControls.start(e)}
         initial="default"
         animate={bottomSheetState}

--- a/src/components/bottom-sheet/index.tsx
+++ b/src/components/bottom-sheet/index.tsx
@@ -92,21 +92,6 @@ const BottomSheet = ({
 
   return (
     <>
-      {/* background overlay */}
-      <motion.div
-        className="absolute top-0 left-0 w-screen h-[100vh]"
-        initial={false}
-        animate={state}
-        variants={{
-          opened: {
-            pointerEvents: 'all',
-          },
-          closed: {
-            pointerEvents: 'none',
-          },
-        }}
-        onTap={() => setBottomSheetState(BOTTOM_SHEET_STATE.Collapsed)}
-      />
       {/* container */}
       <motion.div
         className="fixed top-0 left-0 z-10 w-screen bg-[#212124] rounded-t-[14px] pb-[24px] will-change-transform text-white"

--- a/src/components/bottom-sheet/index.tsx
+++ b/src/components/bottom-sheet/index.tsx
@@ -8,14 +8,22 @@ import { BOTTOM_SHEET_STATE, BottomSheetState } from '@/models/interface'
 
 interface BottomSheetProps {
   body: ReactNode
-  initialState?: BottomSheetState
+  state?: BottomSheetState
 }
 
 const BottomSheet = ({
   body,
-  initialState = BOTTOM_SHEET_STATE.Default,
+  state = BOTTOM_SHEET_STATE.Collapsed,
 }: BottomSheetProps) => {
-  const [state, setState] = useState<BottomSheetState>(initialState)
+  const [prevState, setPrevState] = useState(state)
+  const [bottomSheetState, setBottomSheetState] =
+    useState<BottomSheetState>(state)
+
+  if (prevState !== state) {
+    setPrevState(bottomSheetState)
+    setBottomSheetState(state)
+  }
+
   const [contentRef, contentBounds] = useMeasure()
   const dragControls = useDragControls()
   const size = useWindowSize()
@@ -31,7 +39,7 @@ const BottomSheet = ({
   )
 
   const bodyHeight = useMemo(() => {
-    switch (state) {
+    switch (bottomSheetState) {
       case BOTTOM_SHEET_STATE.Collapsed:
         return 0
       case BOTTOM_SHEET_STATE.Expanded:
@@ -39,7 +47,7 @@ const BottomSheet = ({
       default:
         return defaultHeight - headerHeight
     }
-  }, [defaultHeight, expandedHeight, state])
+  }, [defaultHeight, expandedHeight, bottomSheetState])
 
   const handleDragEnd = (info: PanInfo) => {
     const offsetThreshold = 50
@@ -55,28 +63,28 @@ const BottomSheet = ({
     const offsetY = info.offset.y
     const largeEnoughValue = 200
     const skipOneStep = Math.abs(offsetY) - largeEnoughValue > 0
-    switch (state) {
+    switch (bottomSheetState) {
       case BOTTOM_SHEET_STATE.Default:
         if (offsetY < 0) {
-          setState(BOTTOM_SHEET_STATE.Expanded)
+          setBottomSheetState(BOTTOM_SHEET_STATE.Expanded)
         } else {
-          setState(BOTTOM_SHEET_STATE.Collapsed)
+          setBottomSheetState(BOTTOM_SHEET_STATE.Collapsed)
         }
         break
       case BOTTOM_SHEET_STATE.Expanded:
         if (offsetY <= 0) break
         if (skipOneStep) {
-          setState(BOTTOM_SHEET_STATE.Collapsed)
+          setBottomSheetState(BOTTOM_SHEET_STATE.Collapsed)
         } else {
-          setState(BOTTOM_SHEET_STATE.Default)
+          setBottomSheetState(BOTTOM_SHEET_STATE.Default)
         }
         break
       case BOTTOM_SHEET_STATE.Collapsed:
         if (offsetY >= 0) break
         if (skipOneStep) {
-          setState(BOTTOM_SHEET_STATE.Expanded)
+          setBottomSheetState(BOTTOM_SHEET_STATE.Expanded)
         } else {
-          setState(BOTTOM_SHEET_STATE.Default)
+          setBottomSheetState(BOTTOM_SHEET_STATE.Default)
         }
         break
     }
@@ -97,14 +105,14 @@ const BottomSheet = ({
             pointerEvents: 'none',
           },
         }}
-        onTap={() => setState(BOTTOM_SHEET_STATE.Collapsed)}
+        onTap={() => setBottomSheetState(BOTTOM_SHEET_STATE.Collapsed)}
       />
       {/* container */}
       <motion.div
         className="fixed top-0 left-0 z-10 w-screen bg-[#212124] rounded-t-[14px] pb-[24px] will-change-transform text-white"
         onPointerDown={(e) => dragControls.start(e)}
         initial="default"
-        animate={state}
+        animate={bottomSheetState}
         variants={{
           default: { top: `calc(100vh - ${defaultHeight}px)` },
           expanded: { top: `calc(100vh - ${expandedHeight}px)` },
@@ -117,7 +125,7 @@ const BottomSheet = ({
         dragConstraints={{ top: 0, bottom: 0 }}
         dragElastic={0}
         onDragEnd={(event, info) => handleDragEnd(info)}
-        aria-expanded={state !== BOTTOM_SHEET_STATE.Collapsed}
+        aria-expanded={bottomSheetState !== BOTTOM_SHEET_STATE.Collapsed}
       >
         {/* header */}
         <div className="pt-[16px] px-[20px] cursor-grab">
@@ -128,7 +136,7 @@ const BottomSheet = ({
         <div
           className="transition-all select-none overflow-y-scroll overscroll-contain no-scrollbar"
           style={{ height: bodyHeight }}
-          aria-hidden={state === BOTTOM_SHEET_STATE.Collapsed}
+          aria-hidden={bottomSheetState === BOTTOM_SHEET_STATE.Collapsed}
         >
           {/* content */}
           <div className="px-[20px] pt-[24px]" ref={contentRef}>

--- a/src/hooks/use-mount.ts
+++ b/src/hooks/use-mount.ts
@@ -6,7 +6,7 @@ const useMount = () => {
   useEffect(() => {
     mounted.current = true
     return () => void (mounted.current = false)
-  })
+  }, [])
 
   return mounted
 }


### PR DESCRIPTION
## Issue Number

#16 

## Description

> 구현 내용 및 작업한 내용

- [x] prop 전달로 bottom sheet의 상태를 변경할 수 있게 했습니다.
- [x] 배경을 탭했을 때 bottom sheet가 collapsed 되게 하려고 background overlay를 뒀었는데, 지도가 클릭되지 않는 문제가 있어서 삭제했습니다. 해당 기능은 추후 다시 구현 예정입니다.
- [x] 부모 컴포넌트의 width에 bottom sheet가 딱 맞게끔 수정했습니다.
- [x] 피그마에 맞게 padding을 업데이트했습니다.

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
