### PR TITLE
feat: make floating btn responsive & refactor map

### DIFF
--- a/src/app/map/[mapId]/place-list-bottom-sheet.tsx
+++ b/src/app/map/[mapId]/place-list-bottom-sheet.tsx
@@ -19,7 +19,7 @@ const PlaceListBottomSheet = ({
   const userLocation = useUserGeoLocation()
 
   return (
-    <div className="flex flex-col pt-3.5 px-5">
+    <div className="flex flex-col px-5">
       <div>
         <FilterButton
           numOfSelectedFilter={

--- a/src/components/bottom-sheet/index.tsx
+++ b/src/components/bottom-sheet/index.tsx
@@ -24,22 +24,24 @@ const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
 
     const [contentRef, contentBounds] = useMeasure()
     const dragControls = useDragControls()
-    const size = useWindowSize()
+    const { height: windowHeight } = useWindowSize()
 
-    const headerHeight = 38
+    const headerHeight = 36
     const defaultHeight = Math.min(
       contentBounds.height + headerHeight,
-      size.height / 2,
+      windowHeight / 2,
     )
     const expandedHeight = Math.min(
       contentBounds.height + headerHeight,
-      size.height - headerHeight,
+      (windowHeight * 3) / 4,
     )
 
     const bodyHeight = useMemo(() => {
       switch (bottomSheetState) {
         case BOTTOM_SHEET_STATE.Expanded:
           return expandedHeight - headerHeight
+        case BOTTOM_SHEET_STATE.Collapsed:
+          return 0
         default:
           return defaultHeight - headerHeight
       }
@@ -110,13 +112,13 @@ const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
           aria-expanded={bottomSheetState !== BOTTOM_SHEET_STATE.Collapsed}
         >
           {/* header */}
-          <div className="pt-[16px] cursor-grab">
+          <div className="pt-[16px] pb-[14px] cursor-grab">
             {/* bar */}
             <div className="w-[53px] h-[6px] bg-[#6D717A] my-0 mx-auto rounded-full" />
           </div>
           {/* body */}
           <div
-            className="transition-all select-none overflow-y-scroll overscroll-contain no-scrollbar"
+            className="transition-all duration-300 select-none overflow-y-scroll overscroll-contain no-scrollbar"
             style={{ height: bodyHeight }}
             aria-hidden={bottomSheetState === BOTTOM_SHEET_STATE.Collapsed}
           >

--- a/src/components/korrk-kakao-map.tsx
+++ b/src/components/korrk-kakao-map.tsx
@@ -1,38 +1,23 @@
-import { ReactNode, useRef, useState } from 'react'
 import GpsButton from './kakao-map/gps-button'
 import KakaoMap from './kakao-map/kakao-map'
 import Marker from './kakao-map/marker'
-import BottomSheet from './bottom-sheet'
-import PlaceMapPopup from './place/place-map-popup'
-import useUserGeoLocation from '@/hooks/use-user-geo-location'
-import { formatDistance, getDistance } from '@/utils/location'
 import { PlaceType } from '@/types/api/place'
 
 interface KorrkKakaoMapProps {
   mapMode?: 'search' | 'map'
   places?: PlaceType[]
-  bottomBodyElement?: ReactNode
+  selectedPlace?: PlaceType | null
+  handleClickPlace: (place: PlaceType) => VoidFunction
+  topOfBottomBounds?: number
 }
 
 const KorrkKakaoMap = ({
-  bottomBodyElement,
   mapMode = 'map',
   places = [],
+  selectedPlace,
+  handleClickPlace,
+  topOfBottomBounds = 0,
 }: KorrkKakaoMapProps) => {
-  const [selectedPlace, setSelectedPlace] = useState<PlaceType | null>(null)
-  const bottomRef = useRef<HTMLDivElement>(null)
-  const userLocation = useUserGeoLocation()
-
-  const isOpenBottomSheet = bottomBodyElement && selectedPlace === null
-
-  const handleClickPlace = (place: PlaceType) => () => {
-    if (selectedPlace?.place.id === place.place.id) {
-      setSelectedPlace(null)
-      return
-    }
-    setSelectedPlace(place)
-  }
-
   return (
     <>
       <div className="w-full min-h-dvh flex flex-col justify-center items-center bg-neutral-700 px-5">
@@ -51,43 +36,12 @@ const KorrkKakaoMap = ({
                   ? 'selectedRestaurant'
                   : 'restaurant'
               }
-              onClick={handleClickPlace(place)}
+              onClick={handleClickPlace && handleClickPlace(place)}
             />
           ))}
-          <GpsButton bottomRef={bottomRef} />
+          <GpsButton topOfBottomBounds={topOfBottomBounds} />
         </KakaoMap>
       </div>
-      {selectedPlace === null ? (
-        isOpenBottomSheet && (
-          <BottomSheet ref={bottomRef} body={bottomBodyElement} />
-        )
-      ) : (
-        <PlaceMapPopup
-          ref={bottomRef}
-          className="absolute bottom-5 px-5"
-          image={selectedPlace.place.kakaoPlace.photoList[0]}
-          address={selectedPlace.place.kakaoPlace.address}
-          name={selectedPlace.place.kakaoPlace.name}
-          placeId={selectedPlace.place.kakaoPlace.id}
-          category={selectedPlace.place.kakaoPlace.category}
-          distance={formatDistance(
-            getDistance(
-              userLocation.latitude,
-              userLocation.longitude,
-              selectedPlace.place.y,
-              selectedPlace.place.x,
-            ),
-          )}
-          tags={selectedPlace.tags}
-          pick={{
-            //TODO: userId 연동
-            isLiked: selectedPlace.likedUserIds.includes(1),
-            isMyPick: selectedPlace.createdBy.id === 1,
-            numOfLikes: selectedPlace.likedUserIds.length,
-            onClickLike: () => null,
-          }}
-        />
-      )}
     </>
   )
 }

--- a/src/components/place/place-map-popup.tsx
+++ b/src/components/place/place-map-popup.tsx
@@ -1,29 +1,38 @@
 import { forwardRef } from 'react'
 import { Typography, PickChip, TagList, LikeButton } from '@/components'
-import type { PlaceProps } from './types'
 import type { ClassName } from '@/models/interface'
 import cn from '@/utils/cn'
+import { formatDistance, getDistance } from '@/utils/location'
+import useUserGeoLocation from '@/hooks/use-user-geo-location'
+import type { PlaceType } from '@/types/api/place'
 
-interface PlaceMapPopupProps extends PlaceProps, ClassName {
-  image: string
+interface PlaceMapPopupProps extends ClassName {
+  selectedPlace: PlaceType
 }
 
 // TODO: 클릭 시 식당 상세로 이동 로직
 const PlaceMapPopup = forwardRef<HTMLDivElement, PlaceMapPopupProps>(
-  (
-    {
-      placeId,
-      name,
-      image,
-      distance,
-      address,
-      category,
-      tags,
-      pick,
-      className,
-    },
-    ref,
-  ) => {
+  ({ selectedPlace, className }, ref) => {
+    const userLocation = useUserGeoLocation()
+    const place = selectedPlace.place
+    const distance = formatDistance(
+      getDistance(
+        userLocation.latitude,
+        userLocation.longitude,
+        place.y,
+        place.x,
+      ),
+    )
+    const kakaoPlace = place.kakaoPlace
+    const tags = selectedPlace.tags
+    const pick = {
+      //TODO: userId 연동
+      isLiked: selectedPlace.likedUserIds.includes(1),
+      isMyPick: selectedPlace.createdBy.id === 1,
+      numOfLikes: selectedPlace.likedUserIds.length,
+      onClickLike: () => null,
+    }
+
     return (
       <div
         role="presentation"
@@ -38,10 +47,10 @@ const PlaceMapPopup = forwardRef<HTMLDivElement, PlaceMapPopupProps>(
               <div className="flex flex-col gap-1 ">
                 <div className="flex gap-1.5 items-end">
                   <Typography as="h2" size="h4">
-                    {name}
+                    {kakaoPlace.name}
                   </Typography>
                   <Typography as="span" size="body3" color="neutral-400">
-                    {category}
+                    {kakaoPlace.category}
                   </Typography>
                 </div>
 
@@ -50,7 +59,7 @@ const PlaceMapPopup = forwardRef<HTMLDivElement, PlaceMapPopupProps>(
                     {distance}
                   </Typography>
                   <Typography as="span" size="body3" color="neutral-300">
-                    {address}
+                    {kakaoPlace.address}
                   </Typography>
                 </div>
               </div>
@@ -67,9 +76,13 @@ const PlaceMapPopup = forwardRef<HTMLDivElement, PlaceMapPopupProps>(
               )}
             </div>
 
-            <img className="rounded-md w-20 h-20" src={image} alt="식당" />
+            <img
+              className="rounded-md w-20 h-20"
+              src={kakaoPlace.photoList?.[0]}
+              alt="식당"
+            />
           </div>
-          {tags?.length && <TagList placeId={placeId} tags={tags} />}
+          {tags?.length && <TagList placeId={kakaoPlace.id} tags={tags} />}
         </section>
       </div>
     )


### PR DESCRIPTION
## Issue Number

#58 

## Description

> 구현 내용 및 작업한 내용

- [x] 바텀 시트 CSS를 수정했습니다.
    - style에 지정한 height를 삭제해서 useMeasure에서 바텀 시트 높이를 정확하게 파악할 수 있게 했습니다.
    - window size의 3/4 지점까지만 확장(Expanded)되게 제한했습니다.
    - header 높이 및 padding을 수정했습니다.
- [x] floating GPS 버튼의 위치가 하단의 콘텐츠의 위치에 따라 움직이게 했습니다.
    - [x] 이 작업을 하면서 map 관련 컴포넌트들을 리팩토링 했습니다.

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- TODO로 되어있는 것들은 재석님이 남겨주신 건데, #68 에서 user 정보 가져오는 작업 추가하면서 같이 작업해주셔도 좋을 것 같습니다~

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
