### PR TITLE
feat: get httponly cookie from sever

### DIFF
--- a/src/app/api/token/route.ts
+++ b/src/app/api/token/route.ts
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers'
+import { AUTHORIZATION } from '@/constants/cookie'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const cookieStore = cookies()
+  const token = cookieStore.get(AUTHORIZATION)
+
+  if (!token?.value) {
+    return NextResponse.json(
+      { message: 'Unauthorized', statusCode: 401 },
+      {
+        status: 401,
+      },
+    )
+  }
+
+  return NextResponse.json({
+    message: 'success',
+    data: { token: token.value },
+  })
+}

--- a/src/app/intro/page.tsx
+++ b/src/app/intro/page.tsx
@@ -15,6 +15,9 @@ import { inviteCodeStorage } from '@/utils/storage'
 import { useIsServer } from '@/hooks/use-is-server'
 import { getUser } from '@/services/user'
 import { getMapId } from '@/services/map-id'
+import { parseJSON } from '@/utils/api/parse-json'
+import type { Token } from '@/models/user.interface'
+import type { ResponseWithMessage } from '@/types/api'
 
 export interface IntroActionDispatch {
   goNextStep: VoidFunction
@@ -58,7 +61,7 @@ const Intro = () => {
       try {
         if (!authorization) {
           const response = await fetch('/api/token')
-          const { data } = await response.json()
+          const { data } = await parseJSON<ResponseWithMessage<Token>>(response)
           const token = data.token
 
           setAuthorization(!!token)

--- a/src/app/intro/page.tsx
+++ b/src/app/intro/page.tsx
@@ -12,9 +12,7 @@ import LoadingIndicator from '@/components/loading-indicator'
 import { IntroStep } from '@/models/interface'
 import { inviteCodeStorage } from '@/utils/storage'
 
-import useCookie from '@/hooks/use-cookie'
 import { useIsServer } from '@/hooks/use-is-server'
-import { AUTHORIZATION } from '@/constants/cookie'
 import { getUser } from '@/services/user'
 import { getMapId } from '@/services/map-id'
 
@@ -50,29 +48,40 @@ const Step = ({ step, goNextStep }: StepProps) => {
 const Intro = () => {
   const isServer = useIsServer()
 
-  const authorization = useCookie(AUTHORIZATION)
+  const [isLoading, setLoading] = useState(true)
+  const [authorization, setAuthorization] = useState(false)
   const [nickname, setNickname] = useState<string | undefined>()
   const [mapId, setMapId] = useState<string | undefined>()
 
   useEffect(() => {
     ;(async () => {
       try {
-        const user = await getUser()
-        setNickname(user?.nickname)
+        if (!authorization) {
+          const response = await fetch('/api/token')
+          const { data } = await response.json()
+          const token = data.token
 
-        if (user && user.nickname) {
-          const existingMapId = await getMapId()
-          setMapId(existingMapId)
+          setAuthorization(!!token)
         }
-      } catch (err) {
-        setNickname(undefined)
-        setMapId(undefined)
+
+        if (!nickname) {
+          const user = await getUser()
+          setNickname(user?.nickname)
+        }
+
+        const existingMapId = await getMapId()
+        setMapId(existingMapId)
+      } catch {
+      } finally {
+        setLoading(false)
       }
     })()
-  }, [authorization])
+  }, [authorization, nickname])
 
   const getInitialStep = useMemo(() => {
-    if (!authorization) {
+    if (isLoading) {
+      return IntroStep.LOADING
+    } else if (!authorization) {
       return IntroStep.LOGIN
     } else if (!nickname) {
       return IntroStep.NICKNAME
@@ -81,7 +90,7 @@ const Intro = () => {
     } else {
       return IntroStep.INVITE
     }
-  }, [authorization, nickname, mapId])
+  }, [isLoading, authorization, nickname, mapId])
 
   const [step, setStep] = useState<IntroStep>(IntroStep.LOADING)
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+import { cookies } from 'next/headers'
 import { AUTHORIZATION } from '@/constants/cookie'
 
 export const middleware = (request: NextRequest) => {
   const url = request.nextUrl
   const pathname = url.pathname
 
-  const authorization = request.cookies.get(AUTHORIZATION)?.value
+  const authorization = cookies().get(AUTHORIZATION)?.value
 
   if (!authorization && pathname !== '/intro') {
     return NextResponse.redirect(new URL('/intro', request.url))

--- a/src/models/user.interface.ts
+++ b/src/models/user.interface.ts
@@ -8,3 +8,7 @@ export interface User {
   providerId: string
   role: UserRole
 }
+
+export interface Token {
+  token: string
+}

--- a/src/utils/api/api-client-factory.ts
+++ b/src/utils/api/api-client-factory.ts
@@ -1,16 +1,18 @@
 import HTTPClient from './http-client'
 import type { Interceptors, RequestConfig } from './types'
-import { AUTHORIZATION } from '@/constants/cookie'
-import getCookie from '../storage/cookie'
 
-const injectAuthTokenToConfig = (config: RequestConfig) => {
-  const bearerTokenPrefix = 'Bearer%20'
-  const token = getCookie(AUTHORIZATION)?.slice(bearerTokenPrefix.length)
+const injectAuthTokenToConfig = async (config: RequestConfig) => {
   config.headers = config.headers || {}
 
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`
-  }
+  try {
+    const response = await fetch('/api/token')
+    const { data } = await response.json()
+    const token = data.token
+
+    if (token) {
+      config.headers.Authorization = token
+    }
+  } catch {}
 
   return config
 }

--- a/src/utils/api/api-client-factory.ts
+++ b/src/utils/api/api-client-factory.ts
@@ -1,12 +1,15 @@
 import HTTPClient from './http-client'
+import { parseJSON } from './parse-json'
 import type { Interceptors, RequestConfig } from './types'
+import type { ResponseWithMessage } from '@/types/api'
+import type { Token } from '@/models/user.interface'
 
 const injectAuthTokenToConfig = async (config: RequestConfig) => {
   config.headers = config.headers || {}
 
   try {
     const response = await fetch('/api/token')
-    const { data } = await response.json()
+    const { data } = await parseJSON<ResponseWithMessage<Token>>(response)
     const token = data.token
 
     if (token) {


### PR DESCRIPTION
## Description

> 구현 내용 및 작업한 내용

Authorization 쿠키가 httponly 쿠키라 서버에서만 접근이 가능해서, Authorization 쿠키 가져오는 로직을 수정했습니다.

- [x] 클라이언트에서도 Authorization 쿠키에 접근이 가능하도록, route handler에서 쿠키에 접근해 response로 전달하게 했습니다.
- [x] 서버 사이드(middleware)에서는 next/headers를 이용해서 Authorization 쿠키에 접근하게 했습니다.

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- route handler 호출 시에는 `fetch`를 사용하는 건 어떨까요?
- src/app/intro/page.tsx 에서 스텝 체크하는 로직 이대로 괜찮을까요?! useUser 훅도 있으니, useToken 훅과 useMapId 훅도 만들까요?

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
