### PR TITLE
feat: update getMapId logic & add mapId validation

### DIFF
--- a/src/app/map/[mapId]/page.tsx
+++ b/src/app/map/[mapId]/page.tsx
@@ -19,8 +19,9 @@ import BottomSheet from '@/components/bottom-sheet'
 import { APIError } from '@/models/interface'
 import MapInfoModal from './map-info-modal'
 import { User } from '@/models/user.interface'
-import { BOTTOM_SHEET_STATE } from '../../../components/bottom-sheet/constants'
+import { BOTTOM_SHEET_STATE } from '@/components/bottom-sheet/constants'
 import { TagItem } from '@/types/api/maps'
+import { getMapIdFromCookie, updateMapIdCookie } from '@/services/map-id'
 
 export interface FilterIdsType {
   category: string[]
@@ -122,6 +123,11 @@ const MapMain = ({ params: { mapId } }: { params: { mapId: string } }) => {
   }, [])
 
   useEffect(() => {
+    const mapIdFromCookie = getMapIdFromCookie()
+    if (mapId !== mapIdFromCookie) {
+      updateMapIdCookie(mapId)
+    }
+
     const getPlaceList = async () => {
       try {
         const { data: placeList } = await api.place.mapId.get(mapId)

--- a/src/components/intro/steps/invite.tsx
+++ b/src/components/intro/steps/invite.tsx
@@ -22,10 +22,21 @@ const Invite = () => {
   const [showInvitation, setShowInvitation] = useState(false)
 
   useEffect(() => {
-    ;(async () => {
-      const id = await getMapId()
-      setMapId(id)
-    })()
+    const getAndSetMapId = async () => {
+      try {
+        const id = await getMapId()
+
+        if (!id) {
+          throw new Error('잘못된 접근입니다.')
+        }
+
+        setMapId(id)
+      } catch {
+        notify.error('예상치 못한 오류가 발생했습니다.')
+      }
+    }
+
+    getAndSetMapId()
   }, [])
 
   const goHome = () => {

--- a/src/services/map-id.ts
+++ b/src/services/map-id.ts
@@ -2,30 +2,73 @@ import { setCookie } from '@/app/actions'
 import { RECENT_MAP_ID } from '@/constants/cookie'
 import { api } from '@/utils/api'
 import getCookie from '@/utils/storage/cookie'
+import { APIError } from '../models/interface'
 
-const getStoredMapId = (): string | undefined => {
-  const storedMapId = getCookie(RECENT_MAP_ID)
-  // mapId가 유효한지 검사하는 로직이 필요하다면 추가
-  return storedMapId
+export const getMapIdFromCookie = (): string | undefined => {
+  const mapId = getCookie(RECENT_MAP_ID)
+
+  return mapId
 }
 
-const storeMapId = (mapId: string): void => {
+const setMapIdToCookie = (mapId: string): void => {
   setCookie(RECENT_MAP_ID, mapId)
 }
 
-const fetchAndStoreMapId = async (): Promise<string | undefined> => {
+const fetchMapIds = async (): Promise<string[] | undefined> => {
   try {
     const { data: maps } = await api.maps.get()
-    const mapId = maps[0]?.id
+    const mapIds = maps.map((mapItem) => mapItem.id)
 
-    storeMapId(mapId)
+    return mapIds
+  } catch (error) {
+    if (error instanceof APIError || error instanceof Error) {
+      throw new Error(error.message)
+    }
+  }
+}
 
-    return mapId
-  } catch {
-    return undefined
+const validateMapId = (mapId: string, mapIds: string[]) => {
+  return mapIds.includes(mapId)
+}
+
+export const updateMapIdCookie = async (mapId?: string) => {
+  try {
+    const mapIds = await fetchMapIds()
+
+    const noMap = !mapIds || mapIds.length === 0
+    if (noMap) return
+
+    if (mapId && validateMapId(mapId, mapIds)) {
+      setMapIdToCookie(mapId)
+
+      return mapId
+    }
+
+    const mapIdFromCookie = getMapIdFromCookie() || ''
+
+    if (!validateMapId(mapIdFromCookie, mapIds)) {
+      const firstMapId = mapIds[0]
+
+      setMapIdToCookie(firstMapId)
+
+      return firstMapId
+    }
+
+    return mapIdFromCookie
+  } catch (error) {
+    if (error instanceof APIError || error instanceof Error) {
+      throw new Error(error.message)
+    }
   }
 }
 
 export const getMapId = async (): Promise<string | undefined> => {
-  return getStoredMapId() || (await fetchAndStoreMapId())
+  try {
+    const mapId = await updateMapIdCookie()
+    return mapId
+  } catch (error) {
+    if (error instanceof APIError || error instanceof Error) {
+      throw new Error(error.message)
+    }
+  }
 }


### PR DESCRIPTION
## Description

> 구현 내용 및 작업한 내용

- [x] mapId를 가져오는 로직을 변경했습니다.
    - [x] 변경하면서 async await에서 Error를 던져서 async await가 기대한대로 작동하게 하여 안정성을 높였습니다.
- [x] mapId가 유효한지 확인하는 로직을 추가했습니다.
- [x] 진입한 지도의 mapId가 쿠키에 있는 RECENT_MAP_ID와 다르다면, 쿠키의 값을 업데이트했습니다.

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- mapId가 유효한지 체크하는 로직이 무거워보이나요?
- map-id.ts 가 복잡하거나 보기 불편하진 않은지 궁금합니다!

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
