### PR TITLE
refactor: improve /intro page and useFetch

### DIFF
--- a/src/app/intro/page.tsx
+++ b/src/app/intro/page.tsx
@@ -50,7 +50,7 @@ const Intro = () => {
   const isServer = useIsServer()
   const router = useSafeRouter()
 
-  const [Loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(true)
   const [authorization, setAuthorization] = useState(false)
   const [mapId, setMapId] = useState<string | undefined>()
 
@@ -59,7 +59,7 @@ const Intro = () => {
     enabled: authorization,
   })
 
-  const isLoading = Loading || userLoading
+  const isLoading = isServer || loading || userLoading
   const nickname = user?.nickname
   const inviteCode = inviteCodeStorage.getValueOrNull()
 
@@ -159,13 +159,7 @@ const Intro = () => {
   return (
     <div className="bg-neutral-700 h-dvh w-full flex flex-col justify-between">
       <Header />
-      {isLoading || isServer ? (
-        <div className="text-white flex-1 flex items-center justify-center">
-          <LoadingIndicator />
-        </div>
-      ) : (
-        <Step step={step} goNextStep={goNextStep} />
-      )}
+      <Step step={step} goNextStep={goNextStep} />
     </div>
   )
 }

--- a/src/app/map/[mapId]/map-info-modal.tsx
+++ b/src/app/map/[mapId]/map-info-modal.tsx
@@ -29,7 +29,7 @@ const MapList = ({
 }) => {
   const {
     data: maps,
-    loading,
+    isFetching,
     error,
   } = useFetch(api.maps.get, { initialData: [] })
   const router = useSafeRouter()
@@ -41,7 +41,7 @@ const MapList = ({
 
   return (
     <div className="pt-4 pl-5 flex gap-2 justify-start items-center overflow-x-scroll no-scrollbar">
-      {loading && (
+      {isFetching && (
         <ChipButton
           className="py-2 rounded-full flex-shrink-0 bg-transparent"
           fontSize="body1"
@@ -62,7 +62,7 @@ const MapList = ({
           {map.name}
         </ChipButton>
       ))}
-      {!loading && !hasOwnerMap && (
+      {!isFetching && !hasOwnerMap && (
         <ChipButton
           className="px-6 py-2 rounded-full flex-shrink-0"
           onClick={() => router.push('/map/create')}

--- a/src/app/map/[mapId]/map-info-modal.tsx
+++ b/src/app/map/[mapId]/map-info-modal.tsx
@@ -36,7 +36,7 @@ const MapList = ({
   const hasOwnerMap = maps?.some((map) => map.role === 'ADMIN')
 
   if (error) {
-    notify.error('지도 목록을 가지고 오는데 에러가 발생했습니다. ')
+    notify.error('지도 목록을 가져오지 못했습니다.')
   }
 
   return (

--- a/src/app/map/[mapId]/page.tsx
+++ b/src/app/map/[mapId]/page.tsx
@@ -34,7 +34,7 @@ const INITIAL_FILTER_IDS = {
 const MapMain = ({ params: { mapId } }: { params: { mapId: string } }) => {
   const {
     data: userData,
-    loading,
+    isFetching,
     error: userError,
   } = useFetch(api.users.me.get, { key: ['user'] })
   const { data: mapData, error: mapError } = useFetch(
@@ -182,7 +182,7 @@ const MapMain = ({ params: { mapId } }: { params: { mapId: string } }) => {
             <Icon type="caretDown" size="lg" />
           </button>
           <Link href="/setting">
-            <Avatar value={userData?.nickname ?? ''} loading={loading} />
+            <Avatar value={userData?.nickname ?? ''} loading={isFetching} />
           </Link>
         </div>
         <Tooltip

--- a/src/app/map/[mapId]/page.tsx
+++ b/src/app/map/[mapId]/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, useEffect } from 'react'
 import { Avatar, Icon, Typography } from '@/components'
 import Tooltip from '@/components/tooltip'
 import Link from 'next/link'
-import { visitedMapIdsStorage } from '@/utils/storage'
+import { onboardingStorage, visitedMapIdsStorage } from '@/utils/storage'
 import SearchAnchorBox from './search-anchor-box'
 import KorrkKakaoMap from '@/components/korrk-kakao-map'
 import { api } from '@/utils/api'
@@ -125,6 +125,12 @@ const MapMain = ({ params: { mapId } }: { params: { mapId: string } }) => {
       tags: [...prev.tags, value],
     }))
   }
+
+  useEffect(() => {
+    if (onboardingStorage.getValueOrNull()) {
+      onboardingStorage.remove()
+    }
+  }, [])
 
   useEffect(() => {
     const mapIdFromCookie = getMapIdFromCookie()

--- a/src/app/map/[mapId]/page.tsx
+++ b/src/app/map/[mapId]/page.tsx
@@ -66,7 +66,7 @@ const MapMain = ({ params: { mapId } }: { params: { mapId: string } }) => {
 
   const error = userError || mapError || placesError
   if (error) {
-    notify.error(error)
+    notify.error(error.message)
   }
 
   const handleClickPlace = (place: PlaceType) => {

--- a/src/components/intro/steps/nickname.tsx
+++ b/src/components/intro/steps/nickname.tsx
@@ -7,6 +7,7 @@ import type { IntroActionDispatch } from '@/app/intro/page'
 import { api } from '@/utils/api'
 import { notify } from '@/components/common/custom-toast'
 import { countCharacters } from '@/utils/string'
+import { onboardingStorage } from '@/utils/storage'
 
 const MIN_LENGTH = 2
 const MAX_LENGTH = 6
@@ -16,6 +17,8 @@ const Nickname = ({ goNextStep }: IntroActionDispatch) => {
   const handleChange = (value: string) => {
     setNickname(value)
   }
+
+  onboardingStorage.set('true')
 
   const handleClick = async () => {
     try {

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -21,7 +21,7 @@ const useFetch = <T>(
   },
 ) => {
   const [data, setData] = useState<T | null>(options?.initialData || null)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<APIError | null>(null)
 
   const cacheKey = options?.key?.join('')
   const apiKey = options?.key?.join('') ?? queryFn?.toString() ?? ''
@@ -74,9 +74,17 @@ const useFetch = <T>(
             revalidateRoute('token')
             deleteCookie('Authorization')
           }
-          setError(err.message)
+          setError({
+            name: 'API Error',
+            message: err.message,
+            status: err.status,
+          })
         } else {
-          setError('예상치 못한 오류가 발생했습니다.')
+          setError({
+            name: 'Unexpected Error',
+            message: '예상치 못한 오류가 발생했습니다.',
+            status: 418,
+          })
         }
       } finally {
         loadingMap[apiKey] = false

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -107,8 +107,7 @@ const useFetch = <T>(
 
   return {
     data,
-    loading: fetching[apiKey], // fetching으로 대체 예정
-    fetching: fetching[apiKey] ?? false,
+    isFetching: fetching[apiKey] ?? false,
     error,
     status: data ? 'success' : error ? 'error' : disabled ? 'idle' : 'pending',
     revalidate,

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -7,7 +7,7 @@ import { revalidate as revalidateRoute } from '@/utils/api/route'
 import { getTimeDiff } from '@/utils/date'
 
 const cache: Record<string, { data: any; timestamp: Date }> = {}
-const loadingMap: Record<string, boolean> = {}
+const fetching: Record<string, boolean> = {}
 
 const CACHE_TIME = 5 * 60 * 1000 // 5분
 
@@ -25,6 +25,8 @@ const useFetch = <T>(
 
   const cacheKey = options?.key?.join('')
   const apiKey = options?.key?.join('') ?? queryFn?.toString() ?? ''
+
+  const disabled = typeof options?.enabled === 'boolean' && !options.enabled
 
   const revalidate = useCallback((key: string[] | string) => {
     const targetKey = typeof key === 'string' ? key : key.join('')
@@ -45,26 +47,16 @@ const useFetch = <T>(
     }
 
     const fetchData = async () => {
-      if (typeof options?.enabled === 'boolean' && !options.enabled) return
-      if (cacheKey && cache[cacheKey]?.data) {
-        const ms = getTimeDiff(cache[cacheKey].timestamp, new Date())
-        const isExpired = ms >= CACHE_TIME
-        if (!isExpired) {
-          setData(cache[cacheKey].data)
-          handleLoadEnd(cache[cacheKey].data)
-          return
-        }
-        revalidate(cacheKey)
-      }
-
       if (!queryFn) return
 
       try {
-        loadingMap[apiKey] = true
+        fetching[apiKey] = true
+
         const response = await queryFn()
 
         setData(response.data)
         handleLoadEnd(response.data)
+
         if (cacheKey) {
           cache[cacheKey] = { data: response.data, timestamp: new Date() }
         }
@@ -73,6 +65,7 @@ const useFetch = <T>(
           if (err.status === 401) {
             revalidateRoute('token')
             deleteCookie('Authorization')
+            window.location.reload()
           }
           setError({
             name: 'API Error',
@@ -87,15 +80,40 @@ const useFetch = <T>(
           })
         }
       } finally {
-        loadingMap[apiKey] = false
+        fetching[apiKey] = false
       }
     }
 
-    fetchData()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKey, cacheKey, options?.enabled])
+    const getData = async () => {
+      if (disabled) return
 
-  return { data, loading: loadingMap[apiKey], error, revalidate, clear }
+      if (cacheKey && cache[cacheKey]?.data) {
+        const timeDiff = getTimeDiff(cache[cacheKey].timestamp, new Date())
+        const isExpired = timeDiff >= CACHE_TIME
+        if (!isExpired) {
+          setData(cache[cacheKey].data)
+          handleLoadEnd(cache[cacheKey].data)
+          return
+        }
+        revalidate(cacheKey)
+      }
+
+      fetchData()
+    }
+
+    getData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiKey, cacheKey, disabled])
+
+  return {
+    data,
+    loading: fetching[apiKey], // fetching으로 대체 예정
+    fetching: fetching[apiKey] ?? false,
+    error,
+    status: data ? 'success' : error ? 'error' : disabled ? 'idle' : 'pending',
+    revalidate,
+    clear,
+  }
 }
 
 export default useFetch

--- a/src/models/interface.ts
+++ b/src/models/interface.ts
@@ -52,7 +52,8 @@ export interface MutatedAt {
 
 /* Intro */
 export enum IntroStep {
-  LOADING = -1,
+  FORBIDDEN = -1,
+  LOADING,
   LOGIN,
   NICKNAME,
   NEW_MAP,

--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -32,3 +32,6 @@ export const allowUserPositionStorage = new LocalStorageManager<boolean>(
   ALLOW_USER_POSITION,
   false,
 )
+
+export const ONBOARDING = '@@onboarding'
+export const onboardingStorage = new LocalStorageManager<string>(ONBOARDING)


### PR DESCRIPTION
## Issue Number

## Description

> 구현 내용 및 작업한 내용

intro를 안정화하는 작업을 하다가 useFetch도 업데이트했어요

- [x] /intro 접근 권한을 확실하게 했어요 (기존에는 회원가입중이든지 로그인한 유저든지 모두 intro의 초대 페이지에 진입할 수 있었어요)
    - [x] 닉네임을 입력하는 곳으로 이동했다면, 회원가입중(onboarding)이므로 /intro의 초대 화면에 진입할 수 있어요
    - [x] 이미 회원가입했던 사용자가 `/intro`에 접근하면, 
        - 로그인하지 않은 경우 `/intro`의 로그인 화면에만 접근할 수 있어요
        - 로그인을 한 경우 `/`로 이동했다가 지도 홈으로 이동시켜요
- [x] useFetch의 error, status를 업데이트했어요
    - [x] string이었던 error를 APIError로 변경해주었어요
    - [x] useEffect 내부의 `loadingMap`만 사용하면, useFetch가 마운트되자마자는 data도 null, `loadingMap`도 null 또는 false가 되어버려서 보다 더 정확히 useFetch의 상태를 나타내기 위해 `status`를 추가해줬어요. useFetch가 마운트되었고 지금 처리중이라면 `status`가 'pending'이 돼요

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- useFetch에 status를 추가하고, loading은 fetching으로 변경하는 거 어떠신가요? 괜찮다면 기존에 사용되던 loading은 모두 fetching으로 변경하고 loading은 삭제하겠습니다!
- useFetch의 error를 APIError로 변경하면서, 예상하지 못한 에러의 status는 `418 I'm a teapot`로 설정해주었습니당

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
