### PR TITLE
fix: set cookie options exactly the same as server

### DIFF
--- a/src/app/api/token/route.ts
+++ b/src/app/api/token/route.ts
@@ -35,6 +35,9 @@ export async function DELETE() {
   cookieStore.set(AUTHORIZATION, '', {
     maxAge: -1,
     expires: new Date(Date.now() - 1),
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
   })
 
   return NextResponse.json({ message: 'success', data: {} })

--- a/src/app/api/token/route.ts
+++ b/src/app/api/token/route.ts
@@ -33,11 +33,12 @@ export async function DELETE() {
   }
 
   cookieStore.set(AUTHORIZATION, '', {
-    maxAge: -1,
-    expires: new Date(Date.now() - 1),
     httpOnly: true,
-    secure: true,
     sameSite: 'none',
+    secure: true,
+    path: '/',
+    expires: new Date(Date.now() - 1),
+    domain: process.env.NODE_ENV === 'production' ? '.korrk.kr' : 'localhost',
   })
 
   return NextResponse.json({ message: 'success', data: {} })


### PR DESCRIPTION
## Issue Number

## Description

> 구현 내용 및 작업한 내용

- [x] 사실 vercel의 문제가 아니라 httpOnly secure 쿠키의 특성 때문에 options를 동일하게 맞춰주지 않아서 production에서 작동하지 않았던 건 아니었을까요?!

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 이것도 안 되면... 서버에 /logout api 하나 만들어달라고 하는 건 어떨까요... ㅜ_ㅜ

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
