### PR TITLE
fix: prevent rendering of images with empty src

### DIFF
--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -56,7 +56,7 @@ const Invite = async ({
             mapName={mapInfo.name}
             creator={mapInfo.createBy}
             numOfCrews={mapInfo.users.length}
-            images={mapInviteInfo.placePreviewList}
+            images={mapInviteInfo.placePreviewList.filter((photo) => !!photo)}
           />
         </>
       )}

--- a/src/app/search/search-box.tsx
+++ b/src/app/search/search-box.tsx
@@ -97,7 +97,7 @@ const SearchBox = () => {
       }
     }
     fetchMapId()
-  }, [])
+  }, [mapId])
 
   const getSuggestPlaces = useCallback(async () => {
     if (!query || !mapId) return

--- a/src/components/place/menu-list.tsx
+++ b/src/components/place/menu-list.tsx
@@ -21,11 +21,13 @@ const MenuList = ({ className, mainPhotoUrl, menuList }: MenuListProps) => {
         </Typography>
       </div>
 
-      <ProxyImage
-        src={mainPhotoUrl}
-        alt="메인 음식"
-        className="max-w-full rounded-[6px] mt-[10px] object-cover"
-      />
+      {mainPhotoUrl && (
+        <ProxyImage
+          src={mainPhotoUrl}
+          alt="메인 음식"
+          className="max-w-full rounded-[6px] mt-[10px] object-cover"
+        />
+      )}
 
       <ul className="flex flex-col divide-y divide-neutral-600">
         {menuList.map((menu) => (

--- a/src/components/proxy-image.tsx
+++ b/src/components/proxy-image.tsx
@@ -20,14 +20,16 @@ const ProxyImage = ({ src, ...props }: ProxyImageProps) => {
       } catch {}
     }
 
-    convertImage()
+    if (!url && src.startsWith('http')) {
+      convertImage()
+    }
 
     if (url) {
       return () => {
         URL.revokeObjectURL(url)
       }
     }
-  }, [src])
+  }, [src, url])
 
   return <img {...props} src={url || src} />
 }


### PR DESCRIPTION
## Issue Number

## Description

> 구현 내용 및 작업한 내용

- [x] 이미지가 없는 경우 표시하지 않게 했어요
- [x] 캐러셀의 src에는 `public`에 있는 이미지와 remoteURL 두 가지가 모두 들어올 수 있어서, http로 시작하는 url(`http` / `https`)인 경우에만 convertImage를 수행하게 했어요

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
