### PR TITLE
fix: rename all likedUsers to likedUser & add error handling

### DIFF
--- a/src/app/place/[placeId]/place-box.tsx
+++ b/src/app/place/[placeId]/place-box.tsx
@@ -60,25 +60,25 @@ const PlaceBox = ({ place, mapId }: PlaceBoxProps) => {
     mapInfo?.users.find((mapUser) => mapUser.id === user?.id)?.role ?? 'READ'
 
   const numOfLikes = (() => {
-    const likedUsersCount = place.likedUsers?.length ?? 0
+    const likedUserCount = place.likedUser?.length ?? 0
 
-    if (user && place.likedUsers?.find((likeUser) => likeUser.id === user.id)) {
+    if (user && place.likedUser?.find((liked) => liked.id === user.id)) {
       if (isRecentlyLike == null) {
-        return likedUsersCount
+        return likedUserCount
       }
 
       const recentlyLikedBonus = isRecentlyLike ? 0 : -1
-      return likedUsersCount + recentlyLikedBonus
+      return likedUserCount + recentlyLikedBonus
     }
     const recentlyLikedBonus = isRecentlyLike ? 1 : 0
 
-    return likedUsersCount + recentlyLikedBonus
+    return likedUserCount + recentlyLikedBonus
   })()
 
   useEffect(() => {
     if (!place || !user) return
     setIsLikePlace(
-      !!place.likedUsers?.find((likeUser) => likeUser.id === user.id) ?? false,
+      !!place.likedUser?.find((liked) => liked.id === user.id) ?? false,
     )
   }, [user, place])
 
@@ -96,8 +96,7 @@ const PlaceBox = ({ place, mapId }: PlaceBoxProps) => {
     } catch (error) {
       setIsLikePlace(false)
       setIsRecentlyLike(
-        !!place.likedUsers?.find((likeUser) => likeUser.id === user?.id) ??
-          false,
+        !!place.likedUser?.find((liked) => liked.id === user?.id) ?? false,
       )
       if (error instanceof APIError || error instanceof Error) {
         notify.error(error.message)
@@ -119,8 +118,7 @@ const PlaceBox = ({ place, mapId }: PlaceBoxProps) => {
     } catch (error) {
       setIsLikePlace(true)
       setIsRecentlyLike(
-        !!place.likedUsers?.find((likeUser) => likeUser.id === user?.id) ??
-          false,
+        !!place.likedUser?.find((liked) => liked.id === user?.id) ?? false,
       )
       if (error instanceof APIError || error instanceof Error) {
         notify.error(error.message)
@@ -193,7 +191,7 @@ const PlaceBox = ({ place, mapId }: PlaceBoxProps) => {
           address={place.address}
           tags={place.tags}
           rating={place.score}
-          likedUsers={place.likedUsers ?? []}
+          likedUser={place.likedUser ?? []}
           distance={isAllowPosition ? formatDistance(diffDistance) : undefined}
           pick={
             typeof place.createdBy !== 'undefined'
@@ -239,9 +237,9 @@ const PlaceBox = ({ place, mapId }: PlaceBoxProps) => {
                   onUnLikePlace={handleUnLikePlace}
                 />
               ) : (
-                  <Button type="button" onClick={handleRegisterPlace}>
-                    맛집 등록하기
-                  </Button>
+                <Button type="button" onClick={handleRegisterPlace}>
+                  맛집 등록하기
+                </Button>
               )}
             </div>
           </footer>
@@ -250,7 +248,7 @@ const PlaceBox = ({ place, mapId }: PlaceBoxProps) => {
 
       <PlaceDeleteModal
         createdUser={createdUser}
-        likedUsers={place.likedUsers}
+        likedUser={place.likedUser}
         isOpen={isDeleteModalOpen}
         onCancel={() => setIsDeleteModalOpen(false)}
         onConfirm={handleDeletePlace}

--- a/src/app/place/[placeId]/place-delete-modal.tsx
+++ b/src/app/place/[placeId]/place-delete-modal.tsx
@@ -1,10 +1,10 @@
 import BottomModal from '@/components/common/bottom-modal'
-import type { LikeUsers } from '@/components/place/types'
+import type { LikeUser } from '@/components/place/types'
 import type { User } from '@/models/user'
 
 interface PlaceDeleteModalProps {
   createdUser: Omit<User, 'role'> | null
-  likedUsers?: LikeUsers[]
+  likedUser?: LikeUser[]
   isOpen: boolean
   onCancel: VoidFunction
   onConfirm: VoidFunction
@@ -19,15 +19,15 @@ const safeNameWith님 = (name: string) => {
 
 const PlaceDeleteModal = ({
   createdUser,
-  likedUsers,
+  likedUser,
   isOpen,
   onCancel,
   onConfirm,
 }: PlaceDeleteModalProps) => {
-  const numOfLike = likedUsers?.length || 0
+  const numOfLike = likedUser?.length || 0
   const likeCount = (() => {
     if (numOfLike === 0) return 0
-    const isCreateUserLike = !!likedUsers?.find(
+    const isCreateUserLike = !!likedUser?.find(
       (likeUser) => likeUser.id === createdUser?.id,
     )
     return isCreateUserLike ? numOfLike - 1 : numOfLike

--- a/src/app/place/[placeId]/place-liked-users.tsx
+++ b/src/app/place/[placeId]/place-liked-users.tsx
@@ -1,23 +1,19 @@
 import Avatar from '@/components/common/avatar'
 import Typography from '@/components/common/typography'
-import type { LikeUsers } from '@/components/place/types'
+import type { LikeUser } from '@/components/place/types'
 import type { ClassName } from '@/models/common'
 import type { User } from '@/models/user'
 import cn from '@/utils/cn'
 
-interface PlaceLikedUsersProps extends ClassName {
+interface PlaceLikedUserProps extends ClassName {
   me: User | null
-  likedUsers: LikeUsers[]
+  likedUser: LikeUser[]
 }
 
-const PlaceLikedUsers = ({
-  likedUsers,
-  className,
-  me,
-}: PlaceLikedUsersProps) => {
+const PlaceLikedUser = ({ likedUser, className, me }: PlaceLikedUserProps) => {
   return (
     <ul className={cn('flex flex-col pb-6', className)}>
-      {likedUsers.map((user) => (
+      {likedUser.map((user) => (
         <li key={user.id} className="flex items-center gap-2 pt-2">
           <Avatar
             value={user.nickname}
@@ -33,4 +29,4 @@ const PlaceLikedUsers = ({
   )
 }
 
-export default PlaceLikedUsers
+export default PlaceLikedUser

--- a/src/app/place/[placeId]/place-top-information.tsx
+++ b/src/app/place/[placeId]/place-top-information.tsx
@@ -5,7 +5,7 @@ import IconChip from '@/components/common/icon-chip'
 import Typography from '@/components/common/typography'
 import LikeButton from '@/components/like-button'
 import PickChip from '@/components/pick-chip'
-import type { LikeUsers, PlaceProps } from '@/components/place/types'
+import type { LikeUser, PlaceProps } from '@/components/place/types'
 import TagList from '@/components/tag-list'
 import type { ClassName } from '@/models/common'
 import { categoryIcons } from '@/models/map'
@@ -14,12 +14,12 @@ import { roundOnePoint } from '@/utils/number'
 import LikeToolTip from './like-tooltip'
 import BottomModal from '@/components/common/bottom-modal'
 import type { User } from '@/models/user'
-import PlaceLikedUsers from './place-liked-users'
+import PlaceLikedUser from './place-liked-users'
 
 interface PlaceTopInformationProps extends PlaceProps, ClassName {
   rating: number
   user: User | null
-  likedUsers?: LikeUsers[]
+  likedUser?: LikeUser[]
   images?: string[]
 }
 
@@ -35,11 +35,9 @@ const PlaceTopInformation = ({
   tags,
   distance,
   className,
-  likedUsers,
+  likedUser,
 }: PlaceTopInformationProps) => {
-  const [likeUserList, setLikeUserList] = useState<LikeUsers[]>(
-    likedUsers ?? [],
-  )
+  const [likeUserList, setLikeUserList] = useState<LikeUser[]>(likedUser ?? [])
   const [isOpenLikeMembers, setIsOpenLikeMembers] = useState(false)
 
   const handleLikeOrUnLike = (
@@ -50,7 +48,7 @@ const PlaceTopInformation = ({
     pick?.onClickLike(event)
     if (pick?.isLiked) {
       setLikeUserList((prev) =>
-        [...prev].filter((likeUser) => likeUser.id !== user.id),
+        [...prev].filter((liked) => liked.id !== user.id),
       )
     } else {
       setLikeUserList((prev) => [
@@ -140,7 +138,7 @@ const PlaceTopInformation = ({
         layout="none"
         isOpen={isOpenLikeMembers}
         title={`좋아요 ${pick?.numOfLikes ?? 0}`}
-        body={<PlaceLikedUsers likedUsers={likeUserList} me={user} />}
+        body={<PlaceLikedUser likedUser={likeUserList} me={user} />}
         onClose={() => setIsOpenLikeMembers(false)}
         onConfirm={() => {}}
         confirmMessage=""

--- a/src/app/search/[query]/result-place-map-popup.tsx
+++ b/src/app/search/[query]/result-place-map-popup.tsx
@@ -38,7 +38,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
     const { data: user, revalidate } = useFetch(api.users.me.get, {
       onLoadEnd: (userData) => {
         setIsLikePlace(
-          !!place?.likedUsers?.find((likeUser) => likeUser.id === userData.id),
+          !!place?.likedUser?.find((liked) => liked.id === userData.id),
         )
       },
       key: ['user'],
@@ -54,7 +54,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
           })
           setPlace(response.data)
           setIsLikePlace(
-            !!place?.likedUsers?.find((likeUser) => likeUser.id === user?.id),
+            !!place?.likedUser?.find((liked) => liked.id === user?.id),
           )
         } catch (error) {
           if (error instanceof APIError || error instanceof Error) {
@@ -64,27 +64,24 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
           setIsLoading(false)
         }
       })()
-    }, [mapId, kakaoId, user?.id, place?.likedUsers])
+    }, [mapId, kakaoId, user?.id, place?.likedUser])
 
     if (!place) return null
 
     const numOfLikes = (() => {
-      const likedUsersCount = place.likedUsers?.length ?? 0
+      const likedUserCount = place.likedUser?.length ?? 0
 
-      if (
-        user &&
-        !!place.likedUsers?.find((likeUser) => likeUser.id === user.id)
-      ) {
+      if (user && !!place.likedUser?.find((liked) => liked.id === user.id)) {
         if (isRecentlyLike == null) {
-          return likedUsersCount
+          return likedUserCount
         }
 
         const recentlyLikedBonus = isRecentlyLike ? 0 : -1
-        return likedUsersCount + recentlyLikedBonus
+        return likedUserCount + recentlyLikedBonus
       }
       const recentlyLikedBonus = isRecentlyLike ? 1 : 0
 
-      return likedUsersCount + recentlyLikedBonus
+      return likedUserCount + recentlyLikedBonus
     })()
 
     const handleLikePlace = async () => {
@@ -99,7 +96,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
       } catch (error) {
         setIsLikePlace(false)
         setIsRecentlyLike(
-          !!place?.likedUsers?.find((likeUser) => likeUser.id === user?.id),
+          !!place?.likedUser?.find((liked) => liked.id === user?.id),
         )
         if (error instanceof APIError || error instanceof Error) {
           notify.error(error.message)
@@ -119,7 +116,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
       } catch (error) {
         setIsLikePlace(true)
         setIsRecentlyLike(
-          !!place?.likedUsers?.find((likeUser) => likeUser.id === user?.id),
+          !!place?.likedUser?.find((liked) => liked.id === user?.id),
         )
         if (error instanceof APIError || error instanceof Error) {
           notify.error(error.message)

--- a/src/components/intro/steps/login/intro-carousel.tsx
+++ b/src/components/intro/steps/login/intro-carousel.tsx
@@ -4,7 +4,7 @@ import Typography from '@/components/common/typography'
 const Title = ({ content }: { content: string }) => {
   return (
     <div className="whitespace-pre-line px-5 py-12 text-center">
-      <Typography size="body0-2" color="neutral-000">
+      <Typography size="h1" color="neutral-000">
         {content}
       </Typography>
     </div>

--- a/src/components/place/types.ts
+++ b/src/components/place/types.ts
@@ -5,7 +5,7 @@ import type { PlaceType } from '@/models/api/place'
 import type { CategoryIcon } from '@/models/map'
 import type { User } from '@/models/user'
 
-export interface LikeUsers {
+export interface LikeUser {
   id: User['id']
   nickname: string
   profileImage: string

--- a/src/models/api/place.ts
+++ b/src/models/api/place.ts
@@ -1,4 +1,4 @@
-import type { LikeUsers } from '@/components/place/types'
+import type { LikeUser } from '@/components/place/types'
 import type { TagItem } from './maps'
 
 import type { KakaoPlaceDetail } from '@/models/kakao-map'
@@ -14,7 +14,7 @@ export interface PlaceType {
   }
   tags: TagItem[]
   comments: unknown[]
-  likedUser: Pick<LikeUsers, 'id'>[]
+  likedUser: Pick<LikeUser, 'id'>[]
   createdBy: {
     id: number
     nickname: string
@@ -36,7 +36,7 @@ export interface SearchPlace {
   tags: string[]
   createdBy?: Creator
   score: number
-  likedUser: Pick<LikeUsers, 'id'>[]
+  likedUser: Pick<LikeUser, 'id'>[]
 }
 
 export const isSearchPlace = (
@@ -63,7 +63,7 @@ export interface PlaceDetail {
   kakaoId: PlaceType['place']['kakaoPlace']['id']
   mapId: MapInfo['id']
   isRegisteredPlace: boolean
-  likedUsers?: LikeUsers[]
+  likedUser?: LikeUser[]
   tags: TagItem[]
   createdBy?: PlaceType['createdBy']
   name: string


### PR DESCRIPTION
## Issue Number

## Description

> 구현 내용 및 작업한 내용

- [x] likedUsers는 전부 likedUser로 변경!
- [x] /intro 진입 시 GET /users/me나 GET /maps에서 에러가 발생한다면, 에러 토스트 띄우고 로그인 화면 띄우기 (닉네임 입력 또는 지도 이름 입력 화면 안 나오게 하기)

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점


## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
