### PR TITLE
fix: fix places data revalidation and slicing

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { cookies } from 'next/headers'
+import { revalidatePath, revalidateTag } from 'next/cache'
 
 const setCookie = async (name: string, value: string) => {
   cookies().set(name, value)
@@ -10,4 +11,8 @@ const deleteCookie = async (name: string) => {
   cookies().delete(name)
 }
 
-export { setCookie, deleteCookie }
+const revalidatePlaces = async (mapId: string) => {
+  revalidateTag(`places-${mapId}`)
+}
+
+export { setCookie, deleteCookie, revalidatePlaces }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import { revalidatePath, revalidateTag } from 'next/cache'
+import { revalidateTag } from 'next/cache'
 
 const setCookie = async (name: string, value: string) => {
   cookies().set(name, value)

--- a/src/app/map/[mapId]/place-list-bottom-sheet.tsx
+++ b/src/app/map/[mapId]/place-list-bottom-sheet.tsx
@@ -31,7 +31,7 @@ const PlaceListBottomSheet = forwardRef<
     { places, mapId, selectedFilter, onClickFilterButton, onRefreshOldPlace },
     ref,
   ) => {
-    const [placeList, setPlaceList] = useState<PlaceType[]>(places || [])
+    const [placeList, setPlaceList] = useState<PlaceType[]>([])
     const { data: slicedPlaceList, listRef } = useInfiniteScroll<PlaceType>({
       totalData: places || [],
       itemsPerPage: 10,

--- a/src/app/map/[mapId]/place-list-bottom-sheet.tsx
+++ b/src/app/map/[mapId]/place-list-bottom-sheet.tsx
@@ -13,6 +13,7 @@ import { APIError } from '@/models/api/index'
 import type { PlaceType } from '@/models/api/place'
 import { useInfiniteScroll } from '@/hooks/use-infinite-scroll'
 import { api } from '@/utils/api'
+import { revalidatePlaces } from '@/app/actions'
 
 interface PlaceListBottomSheetProps {
   places: PlaceType[] | null
@@ -36,10 +37,11 @@ const PlaceListBottomSheet = forwardRef<
       itemsPerPage: 10,
     })
 
-    const { data: user, revalidate } = useFetch(api.users.me.get, {
+    const { data: user } = useFetch(api.users.me.get, {
       key: ['user'],
     })
     const userId = user?.id
+
     const numOfSelectedFilter =
       (selectedFilter?.category !== 'all' ? 1 : 0) +
       (selectedFilter?.tags.length ?? 0)
@@ -77,7 +79,7 @@ const PlaceListBottomSheet = forwardRef<
             placeId: place.place.id,
           })
         }
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         if (error instanceof APIError) {
           notify.error(error.message)

--- a/src/app/place/[placeId]/layout.tsx
+++ b/src/app/place/[placeId]/layout.tsx
@@ -1,12 +1,17 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 
 import AccessibleIconButton from '@/components/common/accessible-icon-button'
 
 const PlaceDetailLayout = ({ children }: { children: ReactNode }) => {
   const router = useRouter()
+  const pathname = usePathname()
+
+  if (pathname.includes('register')) {
+    return <>{children}</>
+  }
 
   return (
     <div className="relative flex min-h-dvh flex-col bg-neutral-700">

--- a/src/app/place/[placeId]/register/register-box.tsx
+++ b/src/app/place/[placeId]/register/register-box.tsx
@@ -16,6 +16,7 @@ import type { PlaceDetail } from '@/models/api/place'
 import { api } from '@/utils/api'
 import get조사 from '@/utils/조사'
 import useFetch from '@/hooks/use-fetch'
+import { revalidatePlaces } from '@/app/actions'
 
 const toTagNames = (tags: TagItem[]): TagItem['name'][] =>
   tags.map((tag) => tag.name)
@@ -46,7 +47,8 @@ const RegisterBox = ({
         tagNames: toTagNames(selectedTags),
       })
 
-      revalidate(['map-list'])
+      revalidatePlaces(mapId)
+
       notify.success('맛집 등록이 완료되었습니다.')
       router.safeBack({ defaultHref: `/place/${place.kakaoId}` })
     } catch (error) {

--- a/src/app/place/[placeId]/register/register-box.tsx
+++ b/src/app/place/[placeId]/register/register-box.tsx
@@ -15,7 +15,6 @@ import type { TagItem } from '@/models/api/maps'
 import type { PlaceDetail } from '@/models/api/place'
 import { api } from '@/utils/api'
 import get조사 from '@/utils/조사'
-import useFetch from '@/hooks/use-fetch'
 import { revalidatePlaces } from '@/app/actions'
 
 const toTagNames = (tags: TagItem[]): TagItem['name'][] =>
@@ -30,7 +29,6 @@ const RegisterBox = ({
   tags: TagItem[]
   mapId: string
 }) => {
-  const { revalidate } = useFetch()
   const router = useSafeRouter()
   const [selectedTags, setSelectedTags] = useState<TagItem[]>([])
   const [isOpenBackModal, setIsOpenBackModal] = useState(false)

--- a/src/app/profile/[mapId]/[id]/place-item.tsx
+++ b/src/app/profile/[mapId]/[id]/place-item.tsx
@@ -19,6 +19,7 @@ import { api } from '@/utils/api'
 import cn from '@/utils/cn'
 import { roundOnePoint } from '@/utils/number'
 import { getStarByScore } from '@/utils/score'
+import { revalidatePlaces } from '@/app/actions'
 
 interface PlaceItemProps extends ClassName {
   selectedPlace: PlaceType
@@ -29,7 +30,7 @@ interface PlaceItemProps extends ClassName {
 const PlaceItem = forwardRef<HTMLAnchorElement, PlaceItemProps>(
   ({ selectedPlace, className, mapId, onRefreshOldPlace }, ref) => {
     const [isLikePlace, setIsLikePlace] = useState(false)
-    const { data: user, revalidate } = useFetch(api.users.me.get, {
+    const { data: user } = useFetch(api.users.me.get, {
       key: ['user'],
     })
 
@@ -56,7 +57,7 @@ const PlaceItem = forwardRef<HTMLAnchorElement, PlaceItemProps>(
           placeId: place.id,
           mapId,
         })
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         setIsLikePlace(false)
         if (error instanceof APIError || error instanceof Error) {
@@ -78,7 +79,7 @@ const PlaceItem = forwardRef<HTMLAnchorElement, PlaceItemProps>(
           placeId: place.id,
           mapId,
         })
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         setIsLikePlace(true)
         if (error instanceof APIError || error instanceof Error) {

--- a/src/app/search/[query]/result-place-map-popup.tsx
+++ b/src/app/search/[query]/result-place-map-popup.tsx
@@ -22,6 +22,7 @@ import { api } from '@/utils/api'
 import cn from '@/utils/cn'
 import { roundOnePoint } from '@/utils/number'
 import { getStarByScore } from '@/utils/score'
+import { revalidatePlaces } from '@/app/actions'
 
 interface ResultPlaceMapPopupProps extends ClassName {
   mapId: MapInfo['id']
@@ -35,7 +36,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
 
     const [isLoading, setIsLoading] = useState(false)
     const [place, setPlace] = useState<PlaceDetail | null>(null)
-    const { data: user, revalidate } = useFetch(api.users.me.get, {
+    const { data: user } = useFetch(api.users.me.get, {
       onLoadEnd: (userData) => {
         setIsLikePlace(
           !!place?.likedUser?.find((liked) => liked.id === userData.id),
@@ -92,7 +93,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
           placeId: place.id,
           mapId,
         })
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         setIsLikePlace(false)
         setIsRecentlyLike(
@@ -112,7 +113,7 @@ const ResultPlaceMapPopup = forwardRef<HTMLElement, ResultPlaceMapPopupProps>(
           placeId: place.id,
           mapId,
         })
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         setIsLikePlace(true)
         setIsRecentlyLike(

--- a/src/app/search/[query]/result-search-list.tsx
+++ b/src/app/search/[query]/result-search-list.tsx
@@ -15,6 +15,7 @@ import { api } from '@/utils/api'
 import cn from '@/utils/cn'
 import { formatDistance, getDistance } from '@/utils/location'
 import { allowUserPositionStorage } from '@/utils/storage'
+import { revalidatePlaces } from '@/app/actions'
 
 interface ResultSearchListBoxProps extends ClassName {
   places: SearchPlace[]
@@ -26,7 +27,7 @@ const ResultSearchListBox = ({
   places,
   mapId,
 }: ResultSearchListBoxProps) => {
-  const { data: user, revalidate } = useFetch(api.users.me.get, {
+  const { data: user } = useFetch(api.users.me.get, {
     key: ['user'],
   })
   const { userLocation } = useUserGeoLocation()
@@ -87,7 +88,7 @@ const ResultSearchListBox = ({
       if (!mapId) return
       optimisticUpdateLikeOrUnLike(placeId)
       await api.place.mapId.placeId.like.put({ placeId, mapId })
-      revalidate(['places', mapId])
+      revalidatePlaces(mapId)
     } catch (error) {}
   }
 
@@ -96,7 +97,7 @@ const ResultSearchListBox = ({
       if (!mapId) return
       optimisticUpdateLikeOrUnLike(placeId)
       await api.place.mapId.placeId.like.delete({ placeId, mapId })
-      revalidate(['places', mapId])
+      revalidatePlaces(mapId)
     } catch (error) {}
   }
 

--- a/src/components/place/place-map-popup.tsx
+++ b/src/components/place/place-map-popup.tsx
@@ -20,6 +20,7 @@ import cn from '@/utils/cn'
 import { roundOnePoint } from '@/utils/number'
 import { getStarByScore } from '@/utils/score'
 import PlacePopupSkeleton from '@/components/place/place-popup-skeleton'
+import { revalidatePlaces } from '@/app/actions'
 
 interface PlaceMapPopupProps extends ClassName {
   selectedPlace: PlaceType
@@ -30,7 +31,7 @@ interface PlaceMapPopupProps extends ClassName {
 const PlaceMapPopup = forwardRef<HTMLAnchorElement, PlaceMapPopupProps>(
   ({ selectedPlace, className, mapId, onRefreshOldPlace }, ref) => {
     const [isLikePlace, setIsLikePlace] = useState(false)
-    const { data: user, revalidate } = useFetch(api.users.me.get, {
+    const { data: user } = useFetch(api.users.me.get, {
       key: ['user'],
     })
 
@@ -59,7 +60,7 @@ const PlaceMapPopup = forwardRef<HTMLAnchorElement, PlaceMapPopupProps>(
           placeId: place.id,
           mapId,
         })
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         setIsLikePlace(false)
         if (error instanceof APIError || error instanceof Error) {
@@ -81,7 +82,7 @@ const PlaceMapPopup = forwardRef<HTMLAnchorElement, PlaceMapPopupProps>(
           placeId: place.id,
           mapId,
         })
-        revalidate(['places', mapId])
+        revalidatePlaces(mapId)
       } catch (error) {
         setIsLikePlace(true)
         if (error instanceof APIError || error instanceof Error) {

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -136,7 +136,10 @@ const search = {
       mapId,
     }: QueryParams & { mapId: MapInfo['id'] }): Promise<
       ResponseWithMessage<SearchPlace[]>
-    > => client.public.get(`/search/places?q=${q}&rect=${rect}&mapId=${mapId}`),
+    > =>
+      client.public.get(`/search/places?q=${q}&rect=${rect}&mapId=${mapId}`, {
+        tags: ['places', mapId],
+      }),
   },
 }
 


### PR DESCRIPTION
## Issue Number

## Description

> 구현 내용 및 작업한 내용

- [x] server actions로 받아오는 places는 useFetch의 revalidate가 아니라 next fetch의 revalidateTag를 이용해 revalidate 해주었어요
- [x] places 슬라이싱이 올바르게 작동하게 했어요

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

## Checklist

> PR 등록 전 확인한 것

- [x] 올바른 타켓 브랜치를 설정하였는가
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: add login page`)
- [x] Description에 PR을 구체적으로 설명했는가
